### PR TITLE
Add GoogleTest setup and framebuffer test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,9 @@ find_package(GLEW REQUIRED CONFIG)
 
 add_subdirectory(src)
 
+enable_testing()
+add_subdirectory(tests)
+
 target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
 target_link_libraries(${PROJECT_NAME} PRIVATE SDL2::SDL2main SDL2::SDL2-static)
 target_link_libraries(${PROJECT_NAME} PRIVATE SDL2_image::SDL2_image-static)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,23 @@
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz
+)
+FetchContent_MakeAvailable(googletest)
+
+add_executable(framebuffer_test
+    framebuffer_test.cpp
+    ${CMAKE_SOURCE_DIR}/src/Render/framebuffer.cpp
+)
+
+target_include_directories(framebuffer_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/Render
+)
+
+target_link_libraries(framebuffer_test PRIVATE
+    gtest_main
+    SDL2::SDL2main SDL2::SDL2-static
+    GLEW::GLEW
+)
+
+add_test(NAME framebuffer_test COMMAND framebuffer_test)

--- a/tests/framebuffer_test.cpp
+++ b/tests/framebuffer_test.cpp
@@ -1,0 +1,37 @@
+#include <gtest/gtest.h>
+#include <SDL.h>
+#include <GL/glew.h>
+#include "framebuffer.h"
+
+class SDLFixture : public ::testing::Test {
+protected:
+    SDL_Window* window = nullptr;
+    SDL_GLContext context = nullptr;
+
+    void SetUp() override {
+        SDL_Init(SDL_INIT_VIDEO);
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
+        window = SDL_CreateWindow("test", 0, 0, 64, 64, SDL_WINDOW_OPENGL);
+        context = SDL_GL_CreateContext(window);
+        glewExperimental = GL_TRUE;
+        glewInit();
+    }
+
+    void TearDown() override {
+        SDL_GL_DeleteContext(context);
+        SDL_DestroyWindow(window);
+        SDL_Quit();
+    }
+};
+
+TEST_F(SDLFixture, TextureIdNonZero) {
+    Framebuffer fb(64, 64);
+    EXPECT_NE(fb.getTextureID(), 0u);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary
- configure GoogleTest in `tests/`
- add a `framebuffer` test
- enable tests in the top-level CMake build

## Testing
- `cmake ..` *(fails: Could not find SDL2 package)*

------
https://chatgpt.com/codex/tasks/task_e_68489464131483329ad178c2e77b6ec1